### PR TITLE
feat(action): add bootstrap sticky PR comment workflow

### DIFF
--- a/.github/workflows/mergelens-pr-comment.yml
+++ b/.github/workflows/mergelens-pr-comment.yml
@@ -1,0 +1,85 @@
+name: MergeLens PR Comment (Bootstrap)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  post-bootstrap-comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build bootstrap PR comment
+        id: build-comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pull_number = context.payload.pull_request.number;
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number,
+              per_page: 100
+            });
+
+            const additions = files.reduce((sum, file) => sum + file.additions, 0);
+            const deletions = files.reduce((sum, file) => sum + file.deletions, 0);
+
+            const body = [
+              '<!-- mergelens-comment -->',
+              '## 🔎 MergeLens (Bootstrap)',
+              '',
+              'MergeLens is now wired into this PR and ready for richer analysis in upcoming PRs.',
+              '',
+              `- Files changed: **${files.length}**`,
+              `- Additions: **${additions}**`,
+              `- Deletions: **${deletions}**`,
+              '',
+              `Commit: \`${context.payload.pull_request.head.sha.slice(0, 7)}\``,
+              '',
+              '_Next: AI summary + risk hotspots + reviewer checklist._'
+            ].join('\n');
+
+            core.setOutput('body', body);
+
+      - name: Create or update sticky comment
+        uses: actions/github-script@v7
+        env:
+          BODY: ${{ steps.build-comment.outputs.body }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const marker = '<!-- mergelens-comment -->';
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100
+            });
+
+            const existing = comments.find(comment =>
+              comment.user?.type === 'Bot' && comment.body?.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body: process.env.BODY
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body: process.env.BODY
+              });
+            }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ MergeLens is a GitHub-native PR explainer that summarizes pull requests, highlig
 
 ## Status
 
-🚧 Project initialized. Core analysis and GitHub Action integration coming next.
+🚧 Project initialized. Bootstrap GitHub Action now posts/updates a sticky PR comment with basic change stats.
 
 ## Planned milestones
 


### PR DESCRIPTION
## What this PR does
- Adds a new workflow: .github/workflows/mergelens-pr-comment.yml`n- Runs on pull request events (opened, synchronize, eopened)
- Computes basic change stats (files/additions/deletions)
- Creates or updates a sticky PR comment using <!-- mergelens-comment --> marker

## Why
This bootstraps MergeLens directly in CI so every PR gets a consistent, update-in-place comment. It sets the foundation for AI summaries and risk checks in later iterations.

## Validation
- Workflow syntax checked in repo
- Existing TypeScript check remains green

Closes #1