### PR TITLE
feat(core): add PR analyzer and markdown report renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ MergeLens is a GitHub-native PR explainer that summarizes pull requests, highlig
 3. Post/update sticky PR comment
 4. Add config support (`mergelens.config.json`)
 
+## Core module (new)
+
+MergeLens now exposes a reusable TypeScript core:
+
+- `analyzePullRequest(pr)` → baseline heuristic analysis
+- `renderMarkdownReport(pr, analysis)` → PR-ready markdown output
+
 ## Quickstart
 
 ```bash

--- a/src/core/analyzer.ts
+++ b/src/core/analyzer.ts
@@ -1,0 +1,110 @@
+import type {
+  AnalysisFinding,
+  PullRequestAnalysis,
+  PullRequestData,
+  RiskLevel
+} from "./types.js";
+
+const SENSITIVE_PATH_PATTERNS = [
+  /auth/i,
+  /permission/i,
+  /payment/i,
+  /secret/i,
+  /token/i,
+  /infra/i
+];
+
+function maxSeverity(current: RiskLevel, candidate: RiskLevel): RiskLevel {
+  const rank: Record<RiskLevel, number> = { low: 0, medium: 1, high: 2 };
+  return rank[candidate] > rank[current] ? candidate : current;
+}
+
+function hasTestFile(paths: string[]): boolean {
+  return paths.some((path) => /test|spec|__tests__/i.test(path));
+}
+
+export function analyzePullRequest(pr: PullRequestData): PullRequestAnalysis {
+  const totals = pr.files.reduce(
+    (acc, file) => {
+      acc.files += 1;
+      acc.additions += file.additions;
+      acc.deletions += file.deletions;
+      return acc;
+    },
+    { files: 0, additions: 0, deletions: 0 }
+  );
+
+  const findings: AnalysisFinding[] = [];
+  let riskLevel: RiskLevel = "low";
+
+  if (totals.files > 30 || totals.additions + totals.deletions > 1000) {
+    findings.push({
+      id: "large-pr",
+      title: "Large pull request",
+      detail:
+        "This PR is relatively large and may be harder to review thoroughly in one pass.",
+      severity: "high"
+    });
+    riskLevel = maxSeverity(riskLevel, "high");
+  } else if (totals.files > 12 || totals.additions + totals.deletions > 400) {
+    findings.push({
+      id: "medium-size-pr",
+      title: "Moderate-sized pull request",
+      detail:
+        "This PR touches multiple files. Consider reviewing by module or commit.",
+      severity: "medium"
+    });
+    riskLevel = maxSeverity(riskLevel, "medium");
+  }
+
+  const sensitiveFiles = pr.files
+    .map((file) => file.path)
+    .filter((path) =>
+      SENSITIVE_PATH_PATTERNS.some((pattern) => pattern.test(path))
+    );
+
+  if (sensitiveFiles.length > 0) {
+    findings.push({
+      id: "sensitive-paths",
+      title: "Sensitive code paths changed",
+      detail: `Sensitive paths touched: ${sensitiveFiles
+        .slice(0, 5)
+        .join(", ")}${sensitiveFiles.length > 5 ? "..." : ""}`,
+      severity: "high"
+    });
+    riskLevel = maxSeverity(riskLevel, "high");
+  }
+
+  if (!hasTestFile(pr.files.map((file) => file.path)) && totals.additions > 80) {
+    findings.push({
+      id: "missing-tests",
+      title: "No test files detected",
+      detail:
+        "Code changes are non-trivial, but no obvious tests were added/updated.",
+      severity: "medium"
+    });
+    riskLevel = maxSeverity(riskLevel, "medium");
+  }
+
+  const checklist = [
+    "Validate logic changes for edge cases and failure paths.",
+    "Confirm tests cover new or modified behavior.",
+    "Check for backward compatibility and migration impact.",
+    "Verify docs/changelog updates if public behavior changed."
+  ];
+
+  const summary =
+    findings.length === 0
+      ? "PR looks straightforward with no immediate risk flags from baseline heuristics."
+      : `Found ${findings.length} risk signal${
+          findings.length > 1 ? "s" : ""
+        } from baseline heuristics.`;
+
+  return {
+    summary,
+    riskLevel,
+    totals,
+    findings,
+    checklist
+  };
+}

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -1,0 +1,52 @@
+import type { PullRequestAnalysis, PullRequestData } from "./types.js";
+
+function riskBadge(level: PullRequestAnalysis["riskLevel"]): string {
+  switch (level) {
+    case "high":
+      return "🔴 High";
+    case "medium":
+      return "🟠 Medium";
+    default:
+      return "🟢 Low";
+  }
+}
+
+export function renderMarkdownReport(
+  pr: PullRequestData,
+  analysis: PullRequestAnalysis
+): string {
+  const findingsSection =
+    analysis.findings.length === 0
+      ? "- No major risk findings from baseline heuristics."
+      : analysis.findings
+          .map(
+            (finding) =>
+              `- **${finding.title}** (${finding.severity}): ${finding.detail}`
+          )
+          .join("\n");
+
+  const checklistSection = analysis.checklist.map((item) => `- [ ] ${item}`).join("\n");
+
+  return [
+    "<!-- mergelens-comment -->",
+    "## 🔎 MergeLens Report",
+    "",
+    `**PR:** #${pr.number} - ${pr.title}`,
+    `**Repository:** ${pr.repository}`,
+    `**Risk level:** ${riskBadge(analysis.riskLevel)}`,
+    "",
+    "### TL;DR",
+    analysis.summary,
+    "",
+    "### Change stats",
+    `- Files: **${analysis.totals.files}**`,
+    `- Additions: **${analysis.totals.additions}**`,
+    `- Deletions: **${analysis.totals.deletions}**`,
+    "",
+    "### Risk findings",
+    findingsSection,
+    "",
+    "### Reviewer checklist",
+    checklistSection
+  ].join("\n");
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,0 +1,38 @@
+export type FileChange = {
+  path: string;
+  additions: number;
+  deletions: number;
+  patch?: string;
+};
+
+export type PullRequestData = {
+  repository: string;
+  number: number;
+  title: string;
+  body?: string;
+  author: string;
+  baseRef: string;
+  headRef: string;
+  files: FileChange[];
+};
+
+export type RiskLevel = "low" | "medium" | "high";
+
+export type AnalysisFinding = {
+  id: string;
+  title: string;
+  detail: string;
+  severity: RiskLevel;
+};
+
+export type PullRequestAnalysis = {
+  summary: string;
+  riskLevel: RiskLevel;
+  totals: {
+    files: number;
+    additions: number;
+    deletions: number;
+  };
+  findings: AnalysisFinding[];
+  checklist: string[];
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,3 @@
-export type MergeLensStatus = {
-  name: string;
-  version: string;
-  status: "bootstrapped";
-};
-
-export function getStatus(): MergeLensStatus {
-  return {
-    name: "MergeLens",
-    version: "0.1.0",
-    status: "bootstrapped"
-  };
-}
-
-if (import.meta.url === `file://${process.argv[1]}`) {
-  console.log(getStatus());
-}
+export * from "./core/types.js";
+export { analyzePullRequest } from "./core/analyzer.js";
+export { renderMarkdownReport } from "./core/renderer.js";


### PR DESCRIPTION
## What this PR does
- Adds typed core models for PR input + analysis output (src/core/types.ts)
- Adds baseline heuristic analyzer (src/core/analyzer.ts)
  - PR size risk detection
  - Sensitive path detection
  - Missing test signal detection
- Adds markdown report renderer (src/core/renderer.ts)
- Exports core API from src/index.ts`n
## Why
This creates a reusable core module we can wire into GitHub Action execution and later enrich with LLM-powered summaries.

## Validation
- 
pm run check`n- 
pm run build`n
Closes #3