### PR TITLE
feat(config): support mergelens.config.json customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,18 @@ MergeLens is a GitHub-native PR explainer that summarizes pull requests, highlig
 
 MergeLens now exposes a reusable TypeScript core:
 
-- `analyzePullRequest(pr)` → baseline heuristic analysis
+- `analyzePullRequest(pr, { config })` → baseline heuristic analysis
 - `renderMarkdownReport(pr, analysis)` → PR-ready markdown output
+
+## Repository config
+
+You can customize behavior with `mergelens.config.json` at repo root.
+
+- `exclude`: glob patterns ignored from analysis
+- `sensitivePathPatterns`: regex strings used to flag sensitive paths
+- `thresholds`: medium/high size and missing-test thresholds
+
+Start from `mergelens.config.example.json`.
 
 ## Quickstart
 

--- a/mergelens.config.example.json
+++ b/mergelens.config.example.json
@@ -1,0 +1,11 @@
+{
+  "exclude": ["**/*.lock", "**/dist/**", "**/__snapshots__/**"],
+  "sensitivePathPatterns": ["auth", "permission", "payment", "secret", "token", "infra"],
+  "thresholds": {
+    "mediumFiles": 12,
+    "highFiles": 30,
+    "mediumChanges": 400,
+    "highChanges": 1000,
+    "missingTestsMinAdditions": 80
+  }
+}

--- a/src/action/run.ts
+++ b/src/action/run.ts
@@ -2,6 +2,7 @@ import * as core from "@actions/core";
 import * as github from "@actions/github";
 
 import { analyzePullRequest } from "../core/analyzer.js";
+import { loadConfig, shouldExclude } from "../core/config.js";
 import { renderMarkdownReport } from "../core/renderer.js";
 import type { PullRequestData } from "../core/types.js";
 
@@ -23,6 +24,7 @@ async function run(): Promise<void> {
   const octokit = github.getOctokit(token);
   const { owner, repo } = context.repo;
   const pull_number = pullRequest.number;
+  const config = loadConfig(process.cwd());
 
   const files = await octokit.paginate(octokit.rest.pulls.listFiles, {
     owner,
@@ -39,15 +41,17 @@ async function run(): Promise<void> {
     author: pullRequest.user?.login ?? "unknown",
     baseRef: pullRequest.base.ref,
     headRef: pullRequest.head.ref,
-    files: files.map((file) => ({
-      path: file.filename,
-      additions: file.additions,
-      deletions: file.deletions,
-      patch: file.patch ?? undefined
-    }))
+    files: files
+      .filter((file) => !shouldExclude(file.filename, config.exclude))
+      .map((file) => ({
+        path: file.filename,
+        additions: file.additions,
+        deletions: file.deletions,
+        patch: file.patch ?? undefined
+      }))
   };
 
-  const analysis = analyzePullRequest(prData);
+  const analysis = analyzePullRequest(prData, { config });
   const body = renderMarkdownReport(prData, analysis);
 
   const comments = await octokit.paginate(octokit.rest.issues.listComments, {

--- a/src/core/analyzer.ts
+++ b/src/core/analyzer.ts
@@ -4,15 +4,11 @@ import type {
   PullRequestData,
   RiskLevel
 } from "./types.js";
+import type { ResolvedMergeLensConfig } from "./config.js";
 
-const SENSITIVE_PATH_PATTERNS = [
-  /auth/i,
-  /permission/i,
-  /payment/i,
-  /secret/i,
-  /token/i,
-  /infra/i
-];
+type AnalyzeOptions = {
+  config: ResolvedMergeLensConfig;
+};
 
 function maxSeverity(current: RiskLevel, candidate: RiskLevel): RiskLevel {
   const rank: Record<RiskLevel, number> = { low: 0, medium: 1, high: 2 };
@@ -23,7 +19,12 @@ function hasTestFile(paths: string[]): boolean {
   return paths.some((path) => /test|spec|__tests__/i.test(path));
 }
 
-export function analyzePullRequest(pr: PullRequestData): PullRequestAnalysis {
+export function analyzePullRequest(
+  pr: PullRequestData,
+  options: AnalyzeOptions
+): PullRequestAnalysis {
+  const { config } = options;
+
   const totals = pr.files.reduce(
     (acc, file) => {
       acc.files += 1;
@@ -37,7 +38,10 @@ export function analyzePullRequest(pr: PullRequestData): PullRequestAnalysis {
   const findings: AnalysisFinding[] = [];
   let riskLevel: RiskLevel = "low";
 
-  if (totals.files > 30 || totals.additions + totals.deletions > 1000) {
+  if (
+    totals.files > config.thresholds.highFiles ||
+    totals.additions + totals.deletions > config.thresholds.highChanges
+  ) {
     findings.push({
       id: "large-pr",
       title: "Large pull request",
@@ -46,7 +50,10 @@ export function analyzePullRequest(pr: PullRequestData): PullRequestAnalysis {
       severity: "high"
     });
     riskLevel = maxSeverity(riskLevel, "high");
-  } else if (totals.files > 12 || totals.additions + totals.deletions > 400) {
+  } else if (
+    totals.files > config.thresholds.mediumFiles ||
+    totals.additions + totals.deletions > config.thresholds.mediumChanges
+  ) {
     findings.push({
       id: "medium-size-pr",
       title: "Moderate-sized pull request",
@@ -57,11 +64,13 @@ export function analyzePullRequest(pr: PullRequestData): PullRequestAnalysis {
     riskLevel = maxSeverity(riskLevel, "medium");
   }
 
+  const sensitiveMatchers = config.sensitivePathPatterns.map(
+    (pattern) => new RegExp(pattern, "i")
+  );
+
   const sensitiveFiles = pr.files
     .map((file) => file.path)
-    .filter((path) =>
-      SENSITIVE_PATH_PATTERNS.some((pattern) => pattern.test(path))
-    );
+    .filter((path) => sensitiveMatchers.some((pattern) => pattern.test(path)));
 
   if (sensitiveFiles.length > 0) {
     findings.push({
@@ -75,7 +84,10 @@ export function analyzePullRequest(pr: PullRequestData): PullRequestAnalysis {
     riskLevel = maxSeverity(riskLevel, "high");
   }
 
-  if (!hasTestFile(pr.files.map((file) => file.path)) && totals.additions > 80) {
+  if (
+    !hasTestFile(pr.files.map((file) => file.path)) &&
+    totals.additions > config.thresholds.missingTestsMinAdditions
+  ) {
     findings.push({
       id: "missing-tests",
       title: "No test files detected",

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,0 +1,96 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export type MergeLensConfig = {
+  exclude?: string[];
+  sensitivePathPatterns?: string[];
+  thresholds?: {
+    mediumFiles?: number;
+    highFiles?: number;
+    mediumChanges?: number;
+    highChanges?: number;
+    missingTestsMinAdditions?: number;
+  };
+};
+
+export type ResolvedMergeLensConfig = {
+  exclude: string[];
+  sensitivePathPatterns: string[];
+  thresholds: {
+    mediumFiles: number;
+    highFiles: number;
+    mediumChanges: number;
+    highChanges: number;
+    missingTestsMinAdditions: number;
+  };
+};
+
+const DEFAULT_CONFIG: ResolvedMergeLensConfig = {
+  exclude: ["**/*.lock", "**/dist/**", "**/__snapshots__/**"],
+  sensitivePathPatterns: ["auth", "permission", "payment", "secret", "token", "infra"],
+  thresholds: {
+    mediumFiles: 12,
+    highFiles: 30,
+    mediumChanges: 400,
+    highChanges: 1000,
+    missingTestsMinAdditions: 80
+  }
+};
+
+function asStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.filter((v): v is string => typeof v === "string");
+}
+
+export function resolveConfig(raw?: MergeLensConfig): ResolvedMergeLensConfig {
+  return {
+    exclude: raw?.exclude ?? DEFAULT_CONFIG.exclude,
+    sensitivePathPatterns:
+      raw?.sensitivePathPatterns ?? DEFAULT_CONFIG.sensitivePathPatterns,
+    thresholds: {
+      mediumFiles: raw?.thresholds?.mediumFiles ?? DEFAULT_CONFIG.thresholds.mediumFiles,
+      highFiles: raw?.thresholds?.highFiles ?? DEFAULT_CONFIG.thresholds.highFiles,
+      mediumChanges:
+        raw?.thresholds?.mediumChanges ?? DEFAULT_CONFIG.thresholds.mediumChanges,
+      highChanges: raw?.thresholds?.highChanges ?? DEFAULT_CONFIG.thresholds.highChanges,
+      missingTestsMinAdditions:
+        raw?.thresholds?.missingTestsMinAdditions ??
+        DEFAULT_CONFIG.thresholds.missingTestsMinAdditions
+    }
+  };
+}
+
+export function loadConfig(cwd: string): ResolvedMergeLensConfig {
+  const path = join(cwd, "mergelens.config.json");
+
+  if (!existsSync(path)) {
+    return resolveConfig();
+  }
+
+  try {
+    const data = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+    return resolveConfig({
+      exclude: asStringArray(data.exclude),
+      sensitivePathPatterns: asStringArray(data.sensitivePathPatterns),
+      thresholds:
+        typeof data.thresholds === "object" && data.thresholds !== null
+          ? (data.thresholds as MergeLensConfig["thresholds"])
+          : undefined
+    });
+  } catch {
+    return resolveConfig();
+  }
+}
+
+export function globToRegExp(glob: string): RegExp {
+  const escaped = glob
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*\*/g, "::DOUBLE_STAR::")
+    .replace(/\*/g, "[^/]*")
+    .replace(/::DOUBLE_STAR::/g, ".*");
+  return new RegExp(`^${escaped}$`, "i");
+}
+
+export function shouldExclude(path: string, patterns: string[]): boolean {
+  return patterns.some((pattern) => globToRegExp(pattern).test(path));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./core/types.js";
 export { analyzePullRequest } from "./core/analyzer.js";
+export { loadConfig, resolveConfig, shouldExclude } from "./core/config.js";
 export { renderMarkdownReport } from "./core/renderer.js";


### PR DESCRIPTION
## What this PR does
- Adds repo-level config loader (`src/core/config.ts`) for `mergelens.config.json`
- Supports:
  - `exclude` glob patterns
  - `sensitivePathPatterns`
  - size/test thresholds
- Filters excluded files in action runner before analysis
- Passes resolved config into analyzer
- Adds `mergelens.config.example.json`
- Updates README with config usage

## Why
Lets each repository tune MergeLens behavior without changing source code.

## Validation
- `npm run check`
- `npm run build`

Closes #7