### PR TITLE
feat(ai): optional LLM-enhanced summary with fallback

### DIFF
--- a/.github/workflows/mergelens-pr-comment.yml
+++ b/.github/workflows/mergelens-pr-comment.yml
@@ -29,3 +29,5 @@ jobs:
         run: node dist/action/run.js
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          MERGELENS_LLM_MODEL: ${{ vars.MERGELENS_LLM_MODEL }}

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ You can customize behavior with `mergelens.config.json` at repo root.
 
 Start from `mergelens.config.example.json`.
 
+## Optional AI summary
+
+MergeLens can enhance TL;DR with an LLM when credentials are provided.
+
+- `OPENAI_API_KEY` (GitHub secret) enables AI summary mode
+- `MERGELENS_LLM_MODEL` (GitHub variable, optional) overrides default model
+- Without key or on API failure, MergeLens automatically falls back to heuristic summary
+
 ## Quickstart
 
 ```bash

--- a/src/action/run.ts
+++ b/src/action/run.ts
@@ -1,6 +1,7 @@
 import * as core from "@actions/core";
 import * as github from "@actions/github";
 
+import { generateEnhancedSummary } from "../core/ai.js";
 import { analyzePullRequest } from "../core/analyzer.js";
 import { loadConfig, shouldExclude } from "../core/config.js";
 import { renderMarkdownReport } from "../core/renderer.js";
@@ -52,7 +53,12 @@ async function run(): Promise<void> {
   };
 
   const analysis = analyzePullRequest(prData, { config });
-  const body = renderMarkdownReport(prData, analysis);
+  const enhanced = await generateEnhancedSummary(prData, analysis.summary);
+  const body = renderMarkdownReport(prData, {
+    ...analysis,
+    summary: enhanced.summary,
+    summarySource: enhanced.source
+  });
 
   const comments = await octokit.paginate(octokit.rest.issues.listComments, {
     owner,

--- a/src/core/ai.ts
+++ b/src/core/ai.ts
@@ -1,0 +1,75 @@
+import type { PullRequestData } from "./types.js";
+
+export type SummaryResult = {
+  summary: string;
+  source: "heuristic" | "llm";
+};
+
+function buildPrompt(pr: PullRequestData): string {
+  const filesPreview = pr.files
+    .slice(0, 25)
+    .map((file) => `- ${file.path} (+${file.additions} / -${file.deletions})`)
+    .join("\n");
+
+  return [
+    "You are MergeLens, a concise GitHub pull request explainer.",
+    "Write a 2-4 sentence TL;DR for reviewers.",
+    "Focus on functional change, likely impact, and what to verify.",
+    "Avoid hype and uncertainty words.",
+    "",
+    `Repository: ${pr.repository}`,
+    `PR #${pr.number}: ${pr.title}`,
+    `Author: ${pr.author}`,
+    `Base -> Head: ${pr.baseRef} -> ${pr.headRef}`,
+    `Description: ${pr.body ?? "(none)"}`,
+    "",
+    "Changed files:",
+    filesPreview || "(none)",
+    "",
+    "Return only plain text summary."
+  ].join("\n");
+}
+
+export async function generateEnhancedSummary(
+  pr: PullRequestData,
+  fallbackSummary: string
+): Promise<SummaryResult> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return { summary: fallbackSummary, source: "heuristic" };
+  }
+
+  const model = process.env.MERGELENS_LLM_MODEL ?? "gpt-4.1-mini";
+
+  try {
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`
+      },
+      body: JSON.stringify({
+        model,
+        temperature: 0.2,
+        messages: [{ role: "user", content: buildPrompt(pr) }]
+      })
+    });
+
+    if (!response.ok) {
+      return { summary: fallbackSummary, source: "heuristic" };
+    }
+
+    const data = (await response.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+    const content = data.choices?.[0]?.message?.content?.trim();
+
+    if (!content) {
+      return { summary: fallbackSummary, source: "heuristic" };
+    }
+
+    return { summary: content, source: "llm" };
+  } catch {
+    return { summary: fallbackSummary, source: "heuristic" };
+  }
+}

--- a/src/core/analyzer.ts
+++ b/src/core/analyzer.ts
@@ -114,6 +114,7 @@ export function analyzePullRequest(
 
   return {
     summary,
+    summarySource: "heuristic",
     riskLevel,
     totals,
     findings,

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -34,6 +34,7 @@ export function renderMarkdownReport(
     `**PR:** #${pr.number} - ${pr.title}`,
     `**Repository:** ${pr.repository}`,
     `**Risk level:** ${riskBadge(analysis.riskLevel)}`,
+    `**Summary source:** ${analysis.summarySource === "llm" ? "🤖 LLM" : "🧠 Heuristic fallback"}`,
     "",
     "### TL;DR",
     analysis.summary,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -27,6 +27,7 @@ export type AnalysisFinding = {
 
 export type PullRequestAnalysis = {
   summary: string;
+  summarySource: "heuristic" | "llm";
   riskLevel: RiskLevel;
   totals: {
     files: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./core/types.js";
+export { generateEnhancedSummary } from "./core/ai.js";
 export { analyzePullRequest } from "./core/analyzer.js";
 export { loadConfig, resolveConfig, shouldExclude } from "./core/config.js";
 export { renderMarkdownReport } from "./core/renderer.js";


### PR DESCRIPTION
## What this PR does
- Adds optional LLM summary module (`src/core/ai.ts`)
- Uses `OPENAI_API_KEY` + optional `MERGELENS_LLM_MODEL`
- Enhances PR TL;DR when available
- Falls back to heuristic summary automatically on missing key/failure
- Shows summary source in comment output (LLM vs heuristic fallback)
- Wires optional env vars in workflow

## Why
Improves explanation quality without making workflow brittle.

## Validation
- `npm run check`
- `npm run build`

Closes #9