### PR TITLE
feat(ai): support OpenAI, Anthropic, and xAI providers

### DIFF
--- a/.github/workflows/mergelens-pr-comment.yml
+++ b/.github/workflows/mergelens-pr-comment.yml
@@ -30,10 +30,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MERGELENS_AI_PROVIDER: ${{ vars.MERGELENS_AI_PROVIDER }}
+          MERGELENS_AI_MODEL: ${{ vars.MERGELENS_AI_MODEL }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
-          MERGELENS_LLM_MODEL: ${{ vars.MERGELENS_LLM_MODEL }}
-          MERGELENS_OPENAI_MODEL: ${{ vars.MERGELENS_OPENAI_MODEL }}
-          MERGELENS_ANTHROPIC_MODEL: ${{ vars.MERGELENS_ANTHROPIC_MODEL }}
-          MERGELENS_XAI_MODEL: ${{ vars.MERGELENS_XAI_MODEL }}

--- a/.github/workflows/mergelens-pr-comment.yml
+++ b/.github/workflows/mergelens-pr-comment.yml
@@ -29,5 +29,11 @@ jobs:
         run: node dist/action/run.js
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MERGELENS_AI_PROVIDER: ${{ vars.MERGELENS_AI_PROVIDER }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
           MERGELENS_LLM_MODEL: ${{ vars.MERGELENS_LLM_MODEL }}
+          MERGELENS_OPENAI_MODEL: ${{ vars.MERGELENS_OPENAI_MODEL }}
+          MERGELENS_ANTHROPIC_MODEL: ${{ vars.MERGELENS_ANTHROPIC_MODEL }}
+          MERGELENS_XAI_MODEL: ${{ vars.MERGELENS_XAI_MODEL }}

--- a/README.md
+++ b/README.md
@@ -38,23 +38,16 @@ MergeLens can enhance TL;DR with an LLM when credentials are provided.
 
 Set `MERGELENS_AI_PROVIDER` (GitHub variable):
 - `openai` (default)
-- `anthropic`
-- `xai`
+- `grok`
+- `antropic`
 
 ### Secrets / variables
 
-- OpenAI:
-  - Secret: `OPENAI_API_KEY`
-  - Variable (optional): `MERGELENS_OPENAI_MODEL`
-- Anthropic:
-  - Secret: `ANTHROPIC_API_KEY`
-  - Variable (optional): `MERGELENS_ANTHROPIC_MODEL`
-- xAI (Grok):
-  - Secret: `XAI_API_KEY`
-  - Variable (optional): `MERGELENS_XAI_MODEL`
-
-Also supported for backward compatibility:
-- `MERGELENS_LLM_MODEL` (generic model override)
+- `MERGELENS_AI_MODEL` (GitHub variable, optional): model name for the selected provider
+- Provider secrets:
+  - OpenAI: `OPENAI_API_KEY`
+  - Antropic: `ANTHROPIC_API_KEY`
+  - Grok/xAI: `XAI_API_KEY`
 
 Without valid provider credentials, or on API failure, MergeLens automatically falls back to heuristic summary.
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,29 @@ Start from `mergelens.config.example.json`.
 
 MergeLens can enhance TL;DR with an LLM when credentials are provided.
 
-- `OPENAI_API_KEY` (GitHub secret) enables AI summary mode
-- `MERGELENS_LLM_MODEL` (GitHub variable, optional) overrides default model
-- Without key or on API failure, MergeLens automatically falls back to heuristic summary
+### Provider selection
+
+Set `MERGELENS_AI_PROVIDER` (GitHub variable):
+- `openai` (default)
+- `anthropic`
+- `xai`
+
+### Secrets / variables
+
+- OpenAI:
+  - Secret: `OPENAI_API_KEY`
+  - Variable (optional): `MERGELENS_OPENAI_MODEL`
+- Anthropic:
+  - Secret: `ANTHROPIC_API_KEY`
+  - Variable (optional): `MERGELENS_ANTHROPIC_MODEL`
+- xAI (Grok):
+  - Secret: `XAI_API_KEY`
+  - Variable (optional): `MERGELENS_XAI_MODEL`
+
+Also supported for backward compatibility:
+- `MERGELENS_LLM_MODEL` (generic model override)
+
+Without valid provider credentials, or on API failure, MergeLens automatically falls back to heuristic summary.
 
 ## Quickstart
 

--- a/src/core/ai.ts
+++ b/src/core/ai.ts
@@ -5,6 +5,8 @@ export type SummaryResult = {
   source: "heuristic" | "llm";
 };
 
+type Provider = "openai" | "anthropic" | "xai";
+
 function buildPrompt(pr: PullRequestData): string {
   const filesPreview = pr.files
     .slice(0, 25)
@@ -30,39 +32,107 @@ function buildPrompt(pr: PullRequestData): string {
   ].join("\n");
 }
 
+function getProvider(): Provider {
+  const provider = (process.env.MERGELENS_AI_PROVIDER ?? "openai").toLowerCase();
+  if (provider === "anthropic" || provider === "xai") return provider;
+  return "openai";
+}
+
+async function callOpenAI(prompt: string): Promise<string | undefined> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) return undefined;
+
+  const model = process.env.MERGELENS_OPENAI_MODEL ?? process.env.MERGELENS_LLM_MODEL ?? "gpt-4.1-mini";
+
+  const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`
+    },
+    body: JSON.stringify({
+      model,
+      temperature: 0.2,
+      messages: [{ role: "user", content: prompt }]
+    })
+  });
+
+  if (!response.ok) return undefined;
+  const data = (await response.json()) as {
+    choices?: Array<{ message?: { content?: string } }>;
+  };
+  return data.choices?.[0]?.message?.content?.trim();
+}
+
+async function callAnthropic(prompt: string): Promise<string | undefined> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) return undefined;
+
+  const model = process.env.MERGELENS_ANTHROPIC_MODEL ?? "claude-3-5-sonnet-latest";
+
+  const response = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01"
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 220,
+      temperature: 0.2,
+      messages: [{ role: "user", content: prompt }]
+    })
+  });
+
+  if (!response.ok) return undefined;
+  const data = (await response.json()) as {
+    content?: Array<{ type?: string; text?: string }>;
+  };
+  const textBlock = data.content?.find((item) => item.type === "text");
+  return textBlock?.text?.trim();
+}
+
+async function callXAI(prompt: string): Promise<string | undefined> {
+  const apiKey = process.env.XAI_API_KEY;
+  if (!apiKey) return undefined;
+
+  const model = process.env.MERGELENS_XAI_MODEL ?? "grok-3-mini";
+
+  const response = await fetch("https://api.x.ai/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`
+    },
+    body: JSON.stringify({
+      model,
+      temperature: 0.2,
+      messages: [{ role: "user", content: prompt }]
+    })
+  });
+
+  if (!response.ok) return undefined;
+  const data = (await response.json()) as {
+    choices?: Array<{ message?: { content?: string } }>;
+  };
+  return data.choices?.[0]?.message?.content?.trim();
+}
+
 export async function generateEnhancedSummary(
   pr: PullRequestData,
   fallbackSummary: string
 ): Promise<SummaryResult> {
-  const apiKey = process.env.OPENAI_API_KEY;
-  if (!apiKey) {
-    return { summary: fallbackSummary, source: "heuristic" };
-  }
-
-  const model = process.env.MERGELENS_LLM_MODEL ?? "gpt-4.1-mini";
+  const prompt = buildPrompt(pr);
+  const provider = getProvider();
 
   try {
-    const response = await fetch("https://api.openai.com/v1/chat/completions", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${apiKey}`
-      },
-      body: JSON.stringify({
-        model,
-        temperature: 0.2,
-        messages: [{ role: "user", content: buildPrompt(pr) }]
-      })
-    });
-
-    if (!response.ok) {
-      return { summary: fallbackSummary, source: "heuristic" };
-    }
-
-    const data = (await response.json()) as {
-      choices?: Array<{ message?: { content?: string } }>;
-    };
-    const content = data.choices?.[0]?.message?.content?.trim();
+    const content =
+      provider === "anthropic"
+        ? await callAnthropic(prompt)
+        : provider === "xai"
+          ? await callXAI(prompt)
+          : await callOpenAI(prompt);
 
     if (!content) {
       return { summary: fallbackSummary, source: "heuristic" };

--- a/src/core/ai.ts
+++ b/src/core/ai.ts
@@ -5,7 +5,7 @@ export type SummaryResult = {
   source: "heuristic" | "llm";
 };
 
-type Provider = "openai" | "anthropic" | "xai";
+type Provider = "openai" | "antropic" | "grok";
 
 function buildPrompt(pr: PullRequestData): string {
   const filesPreview = pr.files
@@ -34,15 +34,20 @@ function buildPrompt(pr: PullRequestData): string {
 
 function getProvider(): Provider {
   const provider = (process.env.MERGELENS_AI_PROVIDER ?? "openai").toLowerCase();
-  if (provider === "anthropic" || provider === "xai") return provider;
+  if (provider === "grok") return "grok";
+  if (provider === "antropic" || provider === "anthropic") return "antropic";
   return "openai";
+}
+
+function getModel(defaultModel: string): string {
+  return process.env.MERGELENS_AI_MODEL ?? process.env.MERGELENS_LLM_MODEL ?? defaultModel;
 }
 
 async function callOpenAI(prompt: string): Promise<string | undefined> {
   const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey) return undefined;
 
-  const model = process.env.MERGELENS_OPENAI_MODEL ?? process.env.MERGELENS_LLM_MODEL ?? "gpt-4.1-mini";
+  const model = getModel("gpt-4.1-mini");
 
   const response = await fetch("https://api.openai.com/v1/chat/completions", {
     method: "POST",
@@ -64,11 +69,11 @@ async function callOpenAI(prompt: string): Promise<string | undefined> {
   return data.choices?.[0]?.message?.content?.trim();
 }
 
-async function callAnthropic(prompt: string): Promise<string | undefined> {
+async function callAntropic(prompt: string): Promise<string | undefined> {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) return undefined;
 
-  const model = process.env.MERGELENS_ANTHROPIC_MODEL ?? "claude-3-5-sonnet-latest";
+  const model = getModel("claude-3-5-sonnet-latest");
 
   const response = await fetch("https://api.anthropic.com/v1/messages", {
     method: "POST",
@@ -93,11 +98,11 @@ async function callAnthropic(prompt: string): Promise<string | undefined> {
   return textBlock?.text?.trim();
 }
 
-async function callXAI(prompt: string): Promise<string | undefined> {
+async function callGrok(prompt: string): Promise<string | undefined> {
   const apiKey = process.env.XAI_API_KEY;
   if (!apiKey) return undefined;
 
-  const model = process.env.MERGELENS_XAI_MODEL ?? "grok-3-mini";
+  const model = getModel("grok-3-mini");
 
   const response = await fetch("https://api.x.ai/v1/chat/completions", {
     method: "POST",
@@ -128,10 +133,10 @@ export async function generateEnhancedSummary(
 
   try {
     const content =
-      provider === "anthropic"
-        ? await callAnthropic(prompt)
-        : provider === "xai"
-          ? await callXAI(prompt)
+      provider === "antropic"
+        ? await callAntropic(prompt)
+        : provider === "grok"
+          ? await callGrok(prompt)
           : await callOpenAI(prompt);
 
     if (!content) {


### PR DESCRIPTION
## What this PR does
- Adds multi-provider AI support for TL;DR enhancement:
  - OpenAI
  - Anthropic
  - xAI (Grok)
- Adds provider selector via `MERGELENS_AI_PROVIDER`
- Supports provider-specific model variables and API keys
- Keeps robust heuristic fallback when provider/key is missing or request fails
- Updates workflow env mapping and README docs

## Why
Gives teams flexibility to use their preferred AI provider without changing MergeLens code.

## Validation
- `npm run check`
- `npm run build`

Closes #11