### PR TITLE
feat(action): publish reusable MergeLens GitHub Action

### DIFF
--- a/.github/workflows/mergelens-pr-comment.yml
+++ b/.github/workflows/mergelens-pr-comment.yml
@@ -14,23 +14,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - name: Run MergeLens (dogfood)
+        uses: ./
         with:
-          node-version: 20
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build MergeLens
-        run: npm run build
-
-      - name: Run MergeLens analyzer
-        run: node dist/action/run.js
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MERGELENS_AI_PROVIDER: ${{ vars.MERGELENS_AI_PROVIDER }}
-          MERGELENS_AI_MODEL: ${{ vars.MERGELENS_AI_MODEL }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          ai-provider: ${{ vars.MERGELENS_AI_PROVIDER }}
+          ai-model: ${{ vars.MERGELENS_AI_MODEL }}
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          xai-api-key: ${{ secrets.XAI_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -51,7 +51,36 @@ Set `MERGELENS_AI_PROVIDER` (GitHub variable):
 
 Without valid provider credentials, or on API failure, MergeLens automatically falls back to heuristic summary.
 
-## Quickstart
+## GitHub Action usage
+
+```yaml
+name: MergeLens
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  mergelens:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Adithya-Adi/mergelens@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          ai-provider: ${{ vars.MERGELENS_AI_PROVIDER }}
+          ai-model: ${{ vars.MERGELENS_AI_MODEL }}
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          xai-api-key: ${{ secrets.XAI_API_KEY }}
+```
+
+Use `@main` or a branch ref before the first tagged release.
+
+## Quickstart (local dev)
 
 ```bash
 npm install

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,57 @@
+name: MergeLens
+
+description: Analyze GitHub pull requests and post/update a sticky reviewer summary comment.
+
+author: Adithya-Adi
+
+inputs:
+  github-token:
+    description: GitHub token for reading PR data and writing comments
+    required: true
+  ai-provider:
+    description: AI provider (openai | grok | antropic)
+    required: false
+    default: openai
+  ai-model:
+    description: Model name for selected provider
+    required: false
+  openai-api-key:
+    description: OpenAI API key (required if ai-provider=openai)
+    required: false
+  anthropic-api-key:
+    description: Anthropic API key (required if ai-provider=antropic)
+    required: false
+  xai-api-key:
+    description: xAI API key (required if ai-provider=grok)
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: npm
+        cache-dependency-path: ${{ github.action_path }}/package-lock.json
+
+    - name: Install dependencies
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      run: npm ci
+
+    - name: Build MergeLens
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      run: npm run build
+
+    - name: Run MergeLens analyzer
+      shell: bash
+      run: node "${{ github.action_path }}/dist/action/run.js"
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        MERGELENS_AI_PROVIDER: ${{ inputs.ai-provider }}
+        MERGELENS_AI_MODEL: ${{ inputs.ai-model }}
+        OPENAI_API_KEY: ${{ inputs.openai-api-key }}
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
+        XAI_API_KEY: ${{ inputs.xai-api-key }}

--- a/action.yml
+++ b/action.yml
@@ -32,8 +32,6 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: 20
-        cache: npm
-        cache-dependency-path: ${{ github.action_path }}/package-lock.json
 
     - name: Install dependencies
       shell: bash


### PR DESCRIPTION
## What this PR does
- Adds root `action.yml` so MergeLens can be consumed via `uses: Adithya-Adi/mergelens@<ref>`
- Exposes action inputs for provider/model/API keys
- Packages runtime as a composite action that installs, builds, and runs analyzer
- Refactors internal workflow to dogfood the same action interface (`uses: ./`)
- Updates README with consumer setup snippet

## Validation
- `npm run check`
- `npm run build`

Closes #13